### PR TITLE
[FIX] prevent invalid move to change the color arrangement

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -112,7 +112,7 @@ const App = () => {
     const dragEnd = () => {
         const squareBeingDraggedId = parseInt(squareBeingDragged.getAttribute('data-id'))
         const squareBeingReplacedId = parseInt(squareBeingReplaced.getAttribute('data-id'))
-
+        const originalColorArrangement = [...currentColorArrangement]
         currentColorArrangement[squareBeingReplacedId] = squareBeingDragged.getAttribute('src')
         currentColorArrangement[squareBeingDraggedId] = squareBeingReplaced.getAttribute('src')
 
@@ -136,9 +136,7 @@ const App = () => {
             setSquareBeingDragged(null)
             setSquareBeingReplaced(null)
         } else {
-            currentColorArrangement[squareBeingReplacedId] = squareBeingReplaced.getAttribute('src')
-            currentColorArrangement[squareBeingDraggedId] = squareBeingDragged.getAttribute('src')
-            setCurrentColorArrangement([...currentColorArrangement])
+            setCurrentColorArrangement([...originalColorArrangement])
         }
     }
 


### PR DESCRIPTION
An invalid move was still able to trigger checkFors functions and therefore rearranging the board